### PR TITLE
Add Zed editor instructions

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -2,6 +2,7 @@
 
 - [Helix](helix/README.md)
 - [Neovim](nvim/README.md)
+- [Zed](zed/README.md)
 
 Is your Editor missing? Please refer to your editor's instructions on adding support for Treesitter
 Queries - If possible, please create a PR adding instructions and query files for your editor here.

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -1,0 +1,7 @@
+# Zed support
+
+Instructions for adding tree sitter support for Gren in [Zed](https://zed.dev/).
+
+# Installing
+
+Open up the Extensions settings, search for "Gren" and click Install on the extension named "Gren".


### PR DESCRIPTION
Instructions on how to install the Gren language extension in the Zed editor. 🙂 

The language extension repository is here if you're curious, https://github.com/johanalkstal/gren-lang-extension